### PR TITLE
NFailureDomainsWithFewestMachines implementation

### DIFF
--- a/controllers/controlplane/controlplane.go
+++ b/controllers/controlplane/controlplane.go
@@ -116,9 +116,7 @@ func (r *CritControlPlaneReconciler) reconcileControlPlane(
 		// created control plane will be spread out over failure domains
 		fds := controlPlane.NFailureDomainsWithFewestMachines(ccp.Spec.Replicas)
 		for i := 0; i < ccp.Spec.Replicas; i++ {
-			// this allows cycling through fds when replicas > fds
-			fd := fds[i%len(fds)]
-			if err := r.cloneConfigsAndGenerateMachine(ctx, cluster, ccp, bootstrapSpec, &fd); err != nil {
+			if err := r.cloneConfigsAndGenerateMachine(ctx, cluster, ccp, bootstrapSpec, fds[i]); err != nil {
 				logger.Error(err, "failed to create initial control plane Machine")
 				r.recorder.Eventf(ccp, corev1.EventTypeWarning, "FailedInitialization", "Failed to create initial control plane Machine for cluster %s/%s control plane: %v", cluster.Namespace, cluster.Name, err)
 				return ctrl.Result{}, err

--- a/internal/control_plane.go
+++ b/internal/control_plane.go
@@ -162,6 +162,15 @@ func (c *ControlPlane) FailureDomainWithFewestMachines() *string {
 	return PickFewest(c.FailureDomains().FilterControlPlane(), c.Machines)
 }
 
+// NFailureDomainWithFewestMachines returns N failure domains with the fewest number of machines.
+// Used to distribute control plane replicas over several failure domains
+func (c *ControlPlane) NFailureDomainsWithFewestMachines(replicas int) []string {
+	if len(c.Cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
+		return nil
+	}
+	return NPickFewest(c.FailureDomains().FilterControlPlane(), c.Machines, replicas)
+}
+
 // GenerateCritConfig generates a new crit config for creating new control plane nodes.
 func (c *ControlPlane) GenerateCritConfig(spec *bootstrapv1.CritConfigSpec) *bootstrapv1.CritConfig {
 	// Create an owner reference without a controller reference because the owning controller is the machine controller

--- a/internal/control_plane.go
+++ b/internal/control_plane.go
@@ -164,11 +164,8 @@ func (c *ControlPlane) FailureDomainWithFewestMachines() *string {
 
 // NFailureDomainWithFewestMachines returns N failure domains with the fewest number of machines.
 // Used to distribute control plane replicas over several failure domains
-func (c *ControlPlane) NFailureDomainsWithFewestMachines(replicas int) []string {
-	if len(c.Cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
-		return nil
-	}
-	return NPickFewest(c.FailureDomains().FilterControlPlane(), c.Machines, replicas)
+func (c *ControlPlane) NFailureDomainsWithFewestMachines(replicas int) []*string {
+	return PickNFewest(c.FailureDomains().FilterControlPlane(), c.Machines, replicas)
 }
 
 // GenerateCritConfig generates a new crit config for creating new control plane nodes.

--- a/internal/failure_domain.go
+++ b/internal/failure_domain.go
@@ -87,19 +87,17 @@ func PickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMach
 	return pointer.StringPtr(aggregations[0].id)
 }
 
-// NPickFewest returns N failure domains with the fewest number of machines.
-func NPickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection, replicas int) []string {
+// PickNFewest returns N failure domains with the fewest number of machines.
+func PickNFewest(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection, n int) []*string {
+	fds := make([]*string, n)
 	aggregations := pick(failureDomains, machines)
 	if len(aggregations) == 0 {
-		return nil
+		return fds
 	}
 	sort.Sort(aggregations)
-	fds := make([]string, 0)
-	for i := 0; i < len(aggregations); i++ {
-		fds = append(fds, aggregations[i].id)
-	}
-	if len(aggregations) <= replicas {
-		return fds[:len(aggregations)]
+	for i := 0; i < n; i++ {
+		// allows cycling through fds when n > len(aggregations)
+		fds[i] = pointer.StringPtr(aggregations[i%len(aggregations)].id)
 	}
 	return fds
 }

--- a/internal/failure_domain.go
+++ b/internal/failure_domain.go
@@ -87,6 +87,23 @@ func PickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMach
 	return pointer.StringPtr(aggregations[0].id)
 }
 
+// NPickFewest returns N failure domains with the fewest number of machines.
+func NPickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection, replicas int) []string {
+	aggregations := pick(failureDomains, machines)
+	if len(aggregations) == 0 {
+		return nil
+	}
+	sort.Sort(aggregations)
+	fds := make([]string, 0)
+	for i := 0; i < len(aggregations); i++ {
+		fds = append(fds, aggregations[i].id)
+	}
+	if len(aggregations) <= replicas {
+		return fds[:len(aggregations)]
+	}
+	return fds
+}
+
 func pick(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) failureDomainAggregations {
 	if len(failureDomains) == 0 {
 		return failureDomainAggregations{}


### PR DESCRIPTION
This is a fix for the following [issue](https://github.com/criticalstack/cluster-api-bootstrap-provider-crit/issues/1) regarding new controlplane nodes being spread over failure domains. 